### PR TITLE
Add set +e/set -e around sed calls for macOS compatibility

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -70,15 +70,19 @@ done
 
 # Remove prevoius injected lines if exists
 if [ $OS_NAME = "Darwin" ]; then
+  set +e
   sed -i '' '/___MY_VMOPTIONS_SHELL_FILE=/d' "${PROFILE_PATH}" >/dev/null 2>&1
   sed -i '' '/___MY_VMOPTIONS_SHELL_FILE=/d' "${BASH_PROFILE_PATH}" >/dev/null 2>&1
   sed -i '' '/___MY_VMOPTIONS_SHELL_FILE=/d' "${ZSH_PROFILE_PATH}" >/dev/null 2>&1
-  
+  set -e
+
   echo '</string></array><key>RunAtLoad</key><true/></dict></plist>' >>"${PLIST_PATH}"
 else
+  set +e
   sed -i '/___MY_VMOPTIONS_SHELL_FILE=/d' "${PROFILE_PATH}" >/dev/null 2>&1
   sed -i '/___MY_VMOPTIONS_SHELL_FILE=/d' "${BASH_PROFILE_PATH}" >/dev/null 2>&1
   sed -i '/___MY_VMOPTIONS_SHELL_FILE=/d' "${ZSH_PROFILE_PATH}" >/dev/null 2>&1
+  set -e
 fi
 
 # Inject new lines


### PR DESCRIPTION
This change prevents the script from exiting prematurely on macOS when `sed -i ''` returns a non-zero status (e.g. no matches or BSD `sed` quirks). By temporarily disabling `set -e` around the three `sed` invocations that strip old `___MY_VMOPTIONS_SHELL_FILE` lines, we:

* Avoid unexpected termination of the installer on macOS
* Ensure the cleanup phase always runs, even if no patterns are found
* Maintain strict error checking (`set -e`) for the rest of the script

# Changes

Wrapped the three `sed -i '' …` commands under `set +e / set -e` in the Darwin branch

Applied the same pattern in the Linux branch for consistency (even though busybox/GNU sed is generally reliable)

# Testing

Run `./install.sh` on a clean macOS environment with an existing `.zshrc` containing no injected lines.

Confirm the script completes successfully, outputs here!, and correctly appends the new exec line to `~/.zshrc`.

Re-run to verify that old lines are removed cleanly without early exit.

Please review and merge to restore full macOS support.